### PR TITLE
fix: Connect wallet button not showing when login canceled

### DIFF
--- a/plugins/vue3.ts
+++ b/plugins/vue3.ts
@@ -28,6 +28,7 @@ export const useLock = ({ ...options }) => {
       // @ts-ignore
       provider.value = markRaw(localProvider);
     }
+    if (!provider.value) isAuthenticated.value = false;
     return provider;
   }
 


### PR DESCRIPTION
Fixes #8 

Changes proposed in this pull request:
- Check if provider exists and set isAuthenticated to false if not.
