### PR TITLE
Fix gnosis auto connect when not inside gnosis iframe

### DIFF
--- a/connectors/gnosis.ts
+++ b/connectors/gnosis.ts
@@ -8,6 +8,9 @@ export default class Connector extends LockConnector {
   async connect() {
     let provider;
     try {
+      if (window?.parent === window) {
+        return;
+      }
       // @ts-ignore
       const SafeAppsSDK = (await getSDK()).default.default;
       

--- a/plugins/vue3.ts
+++ b/plugins/vue3.ts
@@ -26,7 +26,8 @@ export const useLock = ({ ...options }) => {
       provider.value = localProvider;
     }
     if (provider.value) {
-      localStorage.setItem(`_${name}.connector`, connector);
+      if (provider.value.connectorName !== 'gnosis')
+        localStorage.setItem(`_${name}.connector`, connector);
       isAuthenticated.value = true;
     }
     return provider;


### PR DESCRIPTION
Fixes #29 

Changes proposed in this pull request:
- Prevent connecting with gnosis-safe when not inside a gnosis-safe iframe. This method of detecting was suggested by the gnosis team on the gnosis discord.
- Do not save gnosis-safe connector inside localStorage