### PR TITLE
Fix logout not working without localStorage

### DIFF
--- a/plugins/vue3.ts
+++ b/plugins/vue3.ts
@@ -26,8 +26,7 @@ export const useLock = ({ ...options }) => {
       provider.value = localProvider;
     }
     if (provider.value) {
-      if (provider.value.connectorName !== 'gnosis')
-        localStorage.setItem(`_${name}.connector`, connector);
+      localStorage.setItem(`_${name}.connector`, connector);
       isAuthenticated.value = true;
     }
     return provider;


### PR DESCRIPTION


Changes proposed in this pull request:
- Reverting change to prevent gnosis inside localStorage because other parts (like logout) of the plugin rely on it. It's also not really needed because we have this in place https://github.com/snapshot-labs/lock/blob/6a6230491d2b66640140abf6b885837c199d9762/connectors/gnosis.ts#L11