### PR TITLE
Update bitkeep name and logo

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,9 +57,9 @@ export function getInjected() {
     icon: 'ipfs://Qma4EJoXZ2CyPfKQHbtjqnLVXP28xFwiXg3KwZa7nMZC19'
   };
   if (web3.isBitKeep) injected = {
-    name: 'BitKeep',
+    name: 'Bitget Wallet',
     id: 'bitkeep',
-    icon: 'ipfs://QmNnBASau839xxF4QSKwBuQXNnaqHJLQYv5oTcHuJyyjcW'
+    icon: 'ipfs://bafkreigkcq5ntckkv3x6xs4qysngwgh77pmbj7apzq4ptavs4lvczq7kni'
   };
   if (web3.isExodus) injected = {
     name: 'Exodus',


### PR DESCRIPTION
Related to https://discord.com/channels/955773041898573854/1031838169282392144/1176071164049772624

It is still bitkeep on docs https://web3.bitget.com/en/docs/guide/wallet/ethereum.html#basic-usage , just name and logo are changed https://www.bitget.com/web3/blog/articles/bitkeep-upgrades-to-bitget-wallet-a-letter-from-the-team