### PR TITLE
fix: fix deprecated usage of `selectedAddress`

### DIFF
--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -19,8 +19,8 @@ export default class Connector extends LockConnector {
 
   async isLoggedIn() {
     if (!window['ethereum']) return false;
-    if (window['ethereum'].selectedAddress) return true;
+    if (window['ethereum'].request({method: 'eth_accounts'})) return true;
     await new Promise((r) => setTimeout(r, 400));
-    return !!window['ethereum'].selectedAddress;
+    return !!window['ethereum'].request({method: 'eth_accounts'});
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/lock",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repository": "snapshot-labs/lock",
   "license": "MIT",
   "main": "dist/lock.cjs.js",


### PR DESCRIPTION
Fix deprecation warning on Metamask:

```
MetaMask: 'ethereum.selectedAddress' is deprecated and may be removed in the future. Please use the 'eth_accounts' RPC method instead.
For more information, see: https://github.com/MetaMask/metamask-improvement-proposals/discussions/23
```