### PR TITLE
feat: add EIP-6963 support

### DIFF
--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -1,8 +1,58 @@
 import LockConnector from '../src/connector';
 
+declare global {
+  interface WindowEventMap {
+      "eip6963:announceProvider": EIP6963AnnounceProviderEvent;
+  }
+}
+
+export class EIP6963RequestProviderEvent extends Event {
+  constructor() {
+      super("eip6963:requestProvider");
+  }
+}
+
+export interface EIP6963AnnounceProviderEvent extends Event {
+  type: "eip6963:announceProvider";
+  detail: EIP6963ProviderDetail;
+}
+
+export interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo;
+  provider: EIP1193Provider;
+}
+
+export interface EIP6963ProviderInfo {
+  uuid: string;
+  name: string;
+  icon: string;
+  rdns: string;
+}
+
+export interface EIP1193Provider {
+  request(request: {
+      method: string;
+      params?: Array<any> | Record<string, any>;
+  }): Promise<any>;
+}
+
+const PREFERRED_PROVIDER = 'io.metamask';
+
 export default class Connector extends LockConnector {
-  async connect() {
-    let provider = this.getEthProvider();
+  providerDetails: EIP6963ProviderDetail[] = []
+
+  constructor(options: string) {
+    super(options);
+
+    window.addEventListener("eip6963:announceProvider", (event: EIP6963AnnounceProviderEvent) => {
+      this.providerDetails.push(event.detail);
+    });
+
+    window.dispatchEvent(new EIP6963RequestProviderEvent());
+  }
+
+  async connect(): Promise<EIP1193Provider | undefined> {
+    let provider = this.getProvider();
 
     if (provider) {
       try {
@@ -12,29 +62,23 @@ export default class Connector extends LockConnector {
         if (e.code === 4001) return;
       }
     } else if (window['web3']) {
-      provider = window['web3'].currentProvider;
+      provider = window['web3'].currentProvider as EIP1193Provider;
     }
     return provider;
   }
 
-  async isLoggedIn() {
-    const provider = this.getEthProvider();
+  async isLoggedIn(): Promise<boolean> {
+    let provider = this.getProvider();
 
     if (!provider) return false;
-    if (provider.request({method: 'eth_accounts'})) return true;
+    if (await provider.request({method: 'eth_accounts'})) return true;
+
     await new Promise((r) => setTimeout(r, 400));
-    return !!provider.request({method: 'eth_accounts'});
+
+    return !!(await provider.request({method: 'eth_accounts'}));
   }
 
-  getEthProvider() {
-    let provider = window['ethereum'];
-
-    if (window['ethereum'].providers?.length) {
-      window['ethereum'].providers.forEach(async (p) => {
-        if (p.isMetaMask) provider = p;
-      });
-    }
-
-    return provider
+  getProvider(): EIP1193Provider | undefined {
+    return this.providerDetails.find(detail => detail.info.rdns === PREFERRED_PROVIDER)?.provider || (window['ethereum'] as EIP1193Provider);
   }
 }

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -2,11 +2,11 @@ import LockConnector from '../src/connector';
 
 export default class Connector extends LockConnector {
   async connect() {
-    let provider;
-    if (window['ethereum']) {
-      provider = window['ethereum'];
+    let provider = this.getEthProvider();
+
+    if (provider) {
       try {
-        await window['ethereum'].request({ method: 'eth_requestAccounts' })
+        await provider.request({ method: 'eth_requestAccounts' })
       } catch (e) {
         console.error(e);
         if (e.code === 4001) return;
@@ -18,9 +18,23 @@ export default class Connector extends LockConnector {
   }
 
   async isLoggedIn() {
-    if (!window['ethereum']) return false;
-    if (window['ethereum'].request({method: 'eth_accounts'})) return true;
+    const provider = this.getEthProvider();
+
+    if (!provider) return false;
+    if (provider.request({method: 'eth_accounts'})) return true;
     await new Promise((r) => setTimeout(r, 400));
-    return !!window['ethereum'].request({method: 'eth_accounts'});
+    return !!provider.request({method: 'eth_accounts'});
+  }
+
+  getEthProvider() {
+    let provider = window['ethereum'];
+
+    if (window['ethereum'].providers?.length) {
+      window['ethereum'].providers.forEach(async (p) => {
+        if (p.isMetaMask) provider = p;
+      });
+    }
+
+    return provider
   }
 }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -5,7 +5,7 @@ export default class Connector {
     this.options = options;
   }
 
-  async connect() {
+  async connect(): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
When multiple wallets are injected, `window['ethereum'].request()` will call the latest injected wallets.

This PR will migrate the injected wallets detection logic to use EIP-6963, and return the correct wallet chosen by the user.

Will also return the list of injected wallets from EIP-6863, instead of hardcoding our own list

### Test


1. `yarn build`
2. `yarn link`
3. Go to your snapshot or sx repo
4. `yarn link "@snapshot-labs/lock"`
5. `yarn dev`
6. Confirm that it uses and remember your chosen wallet