### PR TITLE
fix: skip authentication on locked metamask

### DIFF
--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -17,7 +17,7 @@ export default class Connector extends LockConnector {
             });
           } catch (e: any) {
             console.error(e);
-            if (e.code === 4001) return;
+            if (e.code === 4001 || -32002) return;
           }
         }
 

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -7,8 +7,20 @@ export default class Connector extends LockConnector {
       provider = window['ethereum'];
       try {
         await window['ethereum'].request({ method: 'eth_requestAccounts' })
-      } catch (e) {
+      } catch (e: any) {
         console.error(e);
+        if (e.message = "Already processing eth_requestAccounts. Please wait.") {
+          try {
+            await provider.request({
+              method: "wallet_requestPermissions",
+              params: [{ eth_accounts: {} }],
+            });
+          } catch (e: any) {
+            console.error(e);
+            if (e.code === 4001) return;
+          }
+        }
+
         if (e.code === 4001) return;
       }
     } else if (window['web3']) {

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -19,8 +19,8 @@ export default class Connector extends LockConnector {
 
   async isLoggedIn() {
     if (!window['ethereum']) return false;
-    if (window['ethereum'].selectedAddress) return true;
+    if (window['ethereum'].request({method: 'eth_accounts'})) return true;
     await new Promise((r) => setTimeout(r, 400));
-    return !!window['ethereum'].selectedAddress;
+    return !!window['ethereum'].request({method: 'eth_accounts'});
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/lock",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repository": "snapshot-labs/lock",
   "license": "MIT",
   "main": "dist/lock.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/lock",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "repository": "snapshot-labs/lock",
   "license": "MIT",
   "main": "dist/lock.cjs.js",


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When metamask wallet is locked *AND with a pending unlock request*, the `connect` method will return a valid provider, as if the connection was successful

This return value is wrong, and it should return nothing instead

This also means that any subsequent `connect` call on a locked metamask wallet after being denied once, will not trigger a metamask unlock call again (leaving the user figuring out by himself why the connect is not working, and that he should unlock metamask himself)

#### Reproduction

- Go to https://snapshot.box/#/
- log out and lock metamask
- log in
- do not unlock metamask and close it
- refresh the page
- Click on "Connect wallet", and choose metamask
- The button shows an avatar for `0x000` user, without username
- Clicking on the account button will open connect modal
- Clicking on metamask will do nothing
- This state will stay even after page refresh
- Unlocking metamask will auto-log the user

## 💊 Fixes / Solution

When trying to connect to a wallet in a PENDING UNLOCK state, we should trigger the unlock request again, instead of returning a valid provider

On the UI, this will:
- prevent a Schrödinger user (where the UI consider the user as logged in, even with a locked wallet), when refreshing the page and trying to connect again after denying to unlock metamask
- Trigger a metamask unlock prompt on subsequent connection (instead of just doing nothing)

## 🚧 Changes

- When trying to connect to a locked wallet pending unlocking, trigger unlock request again

## 🛠️ Tests

- `yarn build`
- `yarn link`
- Go to sx-monorepo
- `yarn link @snapshot-labs/lock` 
- `yarn dev`

#### Test 1

- Go to http://localhost:8080
- Log out and lock metamask
- Try to log in
- Ignore the metamask unlock prompt
- The "Connect wallet" button should remain in a loading state
- Open the metamask prompt manually, and unlock it
- You should be logged in with your metamask wallet

#### Test 2

- Go to http://localhost:8080
- Log out and lock metamask
- Try to log in
- Ignore the metamask unlock prompt
- The "Connect wallet" button should remain in a loading state
- Refresh the page
- The account button should be back to "Connect Wallet"
- Clicking on it will open the account modal with the connectors choice
- Clicking on "metamask" will open metamask, prompting you to unlock it

#### Test 2.a

- Unlocking metamask will log you in

#### Test 2.b 

- Do not unlock, and close the metamask popup
- The button should be back the "Connect wallet" state
- Any subsequent click, even after page refresh, should open the account modal, and connecting with metamask will open metamask asking you to unlock it