### PR TITLE
fix: fix and catch more wallet rejection error

### DIFF
--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -19,7 +19,7 @@ export default class Connector extends LockConnector {
           }
         }
 
-        if (e.code === 4001) return;
+        if (e.code === 4001 || e.code === -32002) return;
       }
     } else if (window['web3']) {
       provider = window['web3'].currentProvider;

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -15,7 +15,7 @@ export default class Connector extends LockConnector {
               params: [{ eth_accounts: {} }],
             });
           } catch (e: any) {
-            if (e.code === 4001 || -32002) return;
+            if (e.code === 4001 || e.code === -32002) return;
           }
         }
 

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -8,7 +8,6 @@ export default class Connector extends LockConnector {
       try {
         await window['ethereum'].request({ method: 'eth_requestAccounts' })
       } catch (e: any) {
-        console.error(e);
         if (e.message = "Already processing eth_requestAccounts. Please wait.") {
           try {
             await provider.request({
@@ -16,7 +15,6 @@ export default class Connector extends LockConnector {
               params: [{ eth_accounts: {} }],
             });
           } catch (e: any) {
-            console.error(e);
             if (e.code === 4001 || -32002) return;
           }
         }

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -8,7 +8,7 @@ export default class Connector extends LockConnector {
       try {
         await window['ethereum'].request({ method: 'eth_requestAccounts' })
       } catch (e: any) {
-        if (e.message = "Already processing eth_requestAccounts. Please wait.") {
+        if (e.message.includes("Already processing eth_requestAccounts")) {
           try {
             await provider.request({
               method: "wallet_requestPermissions",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/lock",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "repository": "snapshot-labs/lock",
   "license": "MIT",
   "main": "dist/lock.cjs.js",


### PR DESCRIPTION
This PR fix 

1. fix 2 invalid comparisons 
2. catch and ignore the -32002 error on the second try (fixing issue pointed out in https://github.com/snapshot-labs/sx-monorepo/pull/571#issuecomment-2262410025)
3. remove the `console.log`, as they're already done by the injected wallet, resulting of error logging twice