### PR TITLE
feat: add eip-6963 support

### DIFF
--- a/connectors/fortmatic.ts
+++ b/connectors/fortmatic.ts
@@ -1,8 +1,9 @@
 const get = () => import(/* webpackChunkName: "fortmatic" */ 'fortmatic');
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 export default class Connector extends LockConnector {
-  async connect() {
+  async connect(): Promise<EIP1193Provider | undefined> {
     let provider;
     try {
       const Fortmatic = (await get()).default;

--- a/connectors/gnosis.ts
+++ b/connectors/gnosis.ts
@@ -1,7 +1,8 @@
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 export default class Connector extends LockConnector {
-  async connect() {
+  async connect(): Promise<EIP1193Provider | undefined> {
     let provider;
     try {
       if (window?.parent === window) {

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -1,8 +1,58 @@
 import LockConnector from '../src/connector';
 
+declare global {
+  interface WindowEventMap {
+      "eip6963:announceProvider": EIP6963AnnounceProviderEvent;
+  }
+}
+
+export class EIP6963RequestProviderEvent extends Event {
+  constructor() {
+      super("eip6963:requestProvider");
+  }
+}
+
+export interface EIP6963AnnounceProviderEvent extends Event {
+  type: "eip6963:announceProvider";
+  detail: EIP6963ProviderDetail;
+}
+
+export interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo;
+  provider: EIP1193Provider;
+}
+
+export interface EIP6963ProviderInfo {
+  uuid: string;
+  name: string;
+  icon: string;
+  rdns: string;
+}
+
+export interface EIP1193Provider {
+  request(request: {
+      method: string;
+      params?: Array<any> | Record<string, any>;
+  }): Promise<any>;
+}
+
+const PREFERRED_PROVIDER = 'io.metamask';
+
 export default class Connector extends LockConnector {
-  async connect() {
-    let provider = this.getEthProvider();
+  providerDetails: EIP6963ProviderDetail[] = []
+
+  constructor(options: string) {
+    super(options);
+
+    window.addEventListener("eip6963:announceProvider", (event: EIP6963AnnounceProviderEvent) => {
+      this.providerDetails.push(event.detail);
+    });
+
+    window.dispatchEvent(new EIP6963RequestProviderEvent());
+  }
+
+  async connect(): Promise<EIP1193Provider | undefined> {
+    let provider = this.getProvider();
 
     if (provider) {
       try {
@@ -12,29 +62,23 @@ export default class Connector extends LockConnector {
         if (e.code === 4001) return;
       }
     } else if (window['web3']) {
-      provider = window['web3'].currentProvider;
+      provider = window['web3'].currentProvider as EIP1193Provider;
     }
     return provider;
   }
 
-  async isLoggedIn() {
-    const provider = this.getEthProvider();
+  async isLoggedIn(): Promise<boolean> {
+    let provider = this.getProvider();
 
     if (!provider) return false;
-    if (provider.request({method: 'eth_accounts'})) return true;
+    if (await provider.request({method: 'eth_accounts'})) return true;
+
     await new Promise((r) => setTimeout(r, 400));
-    return !!provider.request({method: 'eth_accounts'});
+
+    return !!(await provider.request({method: 'eth_accounts'}));
   }
 
-  getEthProvider() {
-    let provider = window['ethereum'];
-
-    if (window['ethereum'].providers?.length) {
-      window['ethereum'].providers.forEach(async (p) => {
-        if (p.isMetaMask) provider = p;
-      });
-    }
-
-    return provider
+  getProvider(): EIP1193Provider | undefined {
+    return this.providerDetails.find(detail => detail.info.rdns === PREFERRED_PROVIDER)?.provider || (window['ethereum'] as EIP1193Provider);
   }
 }

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -1,40 +1,5 @@
 import LockConnector from '../src/connector';
-
-declare global {
-  interface WindowEventMap {
-    "eip6963:announceProvider": EIP6963AnnounceProviderEvent;
-  }
-}
-
-export class EIP6963RequestProviderEvent extends Event {
-  constructor() {
-    super("eip6963:requestProvider");
-  }
-}
-
-export interface EIP6963AnnounceProviderEvent extends Event {
-  type: "eip6963:announceProvider";
-  detail: EIP6963ProviderDetail;
-}
-
-export interface EIP6963ProviderDetail {
-  info: EIP6963ProviderInfo;
-  provider: EIP1193Provider;
-}
-
-export interface EIP6963ProviderInfo {
-  uuid: string;
-  name: string;
-  icon: string;
-  rdns: string;
-}
-
-export interface EIP1193Provider {
-  request(request: {
-    method: string;
-    params?: Array<any> | Record<string, any>;
-  }): Promise<any>;
-}
+import { EIP1193Provider, EIP6963ProviderDetail, EIP6963AnnounceProviderEvent, EIP6963RequestProviderEvent } from '../src/types'
 
 const PREFERRED_PROVIDER = 'io.metamask';
 

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -1,7 +1,13 @@
 import LockConnector from '../src/connector';
 import { EIP1193Provider, EIP6963ProviderDetail, EIP6963AnnounceProviderEvent, EIP6963RequestProviderEvent } from '../src/types'
 
-const PREFERRED_PROVIDER = 'io.metamask';
+const PREFERRED_PROVIDER_KEY = 'lock-preferred-injected-provider'
+
+declare global {
+  interface WindowEventMap {
+    "eip6963:announceProvider": EIP6963AnnounceProviderEvent;
+  }
+}
 
 export default class Connector extends LockConnector {
   providerDetails: EIP6963ProviderDetail[] = []
@@ -39,6 +45,7 @@ export default class Connector extends LockConnector {
     } else if (window['web3']) {
       provider = window['web3'].currentProvider as EIP1193Provider;
     }
+
     return provider;
   }
 
@@ -54,6 +61,13 @@ export default class Connector extends LockConnector {
   }
 
   getProvider(): EIP1193Provider | undefined {
-    return this.providerDetails.find(detail => detail.info.rdns === PREFERRED_PROVIDER)?.provider || (window['ethereum'] as EIP1193Provider);
+    const preferredProvider = localStorage.getItem(
+      PREFERRED_PROVIDER_KEY
+    );
+
+    return (
+      this.providerDetails.find(detail => detail.info.rdns === preferredProvider)?.provider
+      || (window['ethereum'] as EIP1193Provider)
+    );
   }
 }

--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -2,11 +2,11 @@ import LockConnector from '../src/connector';
 
 export default class Connector extends LockConnector {
   async connect() {
-    let provider;
-    if (window['ethereum']) {
-      provider = window['ethereum'];
+    let provider = this.getEthProvider();
+
+    if (provider) {
       try {
-        await window['ethereum'].request({ method: 'eth_requestAccounts' })
+        await provider.request({ method: 'eth_requestAccounts' })
       } catch (e) {
         console.error(e);
         if (e.code === 4001) return;
@@ -18,9 +18,23 @@ export default class Connector extends LockConnector {
   }
 
   async isLoggedIn() {
-    if (!window['ethereum']) return false;
-    if (window['ethereum'].request({method: 'eth_accounts'})) return true;
+    const provider = this.getEthProvider();
+
+    if (!provider) return false;
+    if (provider.request({method: 'eth_accounts'})) return true;
     await new Promise((r) => setTimeout(r, 400));
-    return !!window['ethereum'].request({method: 'eth_accounts'});
+    return !!provider.request({method: 'eth_accounts'});
+  }
+
+  getEthProvider() {
+    let provider = window['ethereum'];
+
+    if (window['ethereum'].providers?.length) {
+      window['ethereum'].providers.forEach(async (p) => {
+        if (p.isMetaMask) provider = p;
+      });
+    }
+
+    return provider
   }
 }

--- a/connectors/kaikas.ts
+++ b/connectors/kaikas.ts
@@ -1,7 +1,8 @@
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 export default class Connector extends LockConnector {
-  async connect() {
+  async connect(): Promise<EIP1193Provider | undefined> {
     let provider;
     if (window['klaytn']) {
       provider = window['klaytn'];

--- a/connectors/portis.ts
+++ b/connectors/portis.ts
@@ -1,8 +1,9 @@
 const get = () => import(/* webpackChunkName: "portis" */ '@portis/web3/umd');
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 export default class Connector extends LockConnector {
-  async connect() {
+  async connect(): Promise<EIP1193Provider | undefined> {
     let provider;
     try {
       const Portis = (await get()).default;

--- a/connectors/stargazer.ts
+++ b/connectors/stargazer.ts
@@ -1,11 +1,12 @@
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 export default class Connector extends LockConnector {
-  getProvider(){
+  getProvider(): Promise<EIP1193Provider | undefined> {
     const walletProvider = window['stargazer'];
 
     if(!walletProvider){
-      return null;
+      return;
     }
 
     return walletProvider.getProvider('ethereum');
@@ -17,14 +18,14 @@ export default class Connector extends LockConnector {
     if(!provider){
       return;
     }
-    
-    try{
+
+    try {
       await provider.activate();
-    }catch(e){
+    } catch(e) {
       console.error(e);
       return;
     }
-    
+
     return provider;
   }
 

--- a/connectors/torus.ts
+++ b/connectors/torus.ts
@@ -1,8 +1,9 @@
 const get = () => import(/* webpackChunkName: "torus" */ '@toruslabs/torus-embed');
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 export default class Connector extends LockConnector {
-  async connect() {
+  async connect(): Promise<EIP1193Provider | undefined> {
     let provider;
     try {
       const Torus = (await get()).default;

--- a/connectors/walletconnect.ts
+++ b/connectors/walletconnect.ts
@@ -1,8 +1,9 @@
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 let provider: any;
 export default class Connector extends LockConnector {
-  async connect() {
+  async connect(): Promise<EIP1193Provider | undefined> {
     try {
       const imports = await import(
         "@walletconnect/ethereum-provider"!
@@ -33,12 +34,14 @@ export default class Connector extends LockConnector {
     wcKeys.forEach(key => localStorage.removeItem(key));
   }
 
-  logout() {
+  logout(): boolean {
     if ('disconnect' in provider) {
       provider.disconnect().catch(this.removeHashFromLocalStorage);
       provider = null;
     } else {
       this.removeHashFromLocalStorage();
     }
+
+    return true;
   }
 }

--- a/connectors/walletlink.ts
+++ b/connectors/walletlink.ts
@@ -1,7 +1,8 @@
 import LockConnector from '../src/connector';
+import { EIP1193Provider } from '../src/types';
 
 export default class Connector extends LockConnector {
-  async connect() {
+  async connect(): Promise<EIP1193Provider | undefined> {
     let provider;
     try {
       let CoinbaseWalletSDK = await import(
@@ -23,7 +24,7 @@ export default class Connector extends LockConnector {
     return provider;
   }
 
-  logout() {
+  logout(): boolean {
     if (localStorage) {
       localStorage.removeItem(
         '-walletlink:https://www.walletlink.org:session:id'
@@ -38,6 +39,7 @@ export default class Connector extends LockConnector {
         '-walletlink:https://www.walletlink.org:Addresses'
       );
     }
-    return;
+
+    return true;
   }
 }

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -5,7 +5,7 @@ export default class Connector {
     this.options = options;
   }
 
-  async connect() {
+  async connect(): Promise<any> {
     return;
   }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,15 +1,17 @@
+import { EIP1193Provider} from '../src/types'
+
 export default class Connector {
   public options: any;
 
-  constructor(options: string) {
+  constructor(options: any) {
     this.options = options;
   }
 
-  async connect(): Promise<any> {
+  async connect(): Promise<EIP1193Provider | undefined> {
     return;
   }
 
-  logout(): any {
+  logout(): boolean {
     return true;
   }
 

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,16 +1,15 @@
 import Connector from './connector';
 
 export default class Lock {
-  public connectors = {};
+  public connectors: Record<string, Connector> = {};
   public options = {};
 
   addConnector(connector: any) {
-    this.connectors[connector.key] = connector.connector;
+    this.connectors[connector.key] = new connector.connector(connector.options);
     this.options[connector.key] = connector.options;
   }
 
   getConnector(key: string): Connector {
-    const options = this.options[key];
-    return new this.connectors[key](options);
+    return this.connectors[key];
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,39 @@
+// Interface for Ethereum providers based on the EIP-1193 standard.
+export interface EIP1193Provider {
+  isStatus?: boolean;
+  host?: string;
+  path?: string;
+  sendAsync?: (request: { method: string, params?: Array<unknown> }, callback: (error: Error | null, response: unknown) => void) => void;
+  send?: (request: { method: string, params?: Array<unknown> }, callback: (error: Error | null, response: unknown) => void) => void;
+  request: (request: { method: string, params?: Array<unknown> }) => Promise<unknown>;
+}
+
+declare global {
+  interface WindowEventMap {
+    "eip6963:announceProvider": EIP6963AnnounceProviderEvent;
+  }
+}
+
+export class EIP6963RequestProviderEvent extends Event {
+  constructor() {
+    super("eip6963:requestProvider");
+  }
+}
+
+export interface EIP6963AnnounceProviderEvent extends Event {
+  type: "eip6963:announceProvider";
+  detail: EIP6963ProviderDetail;
+}
+
+export interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo;
+  provider: EIP1193Provider;
+}
+
+export interface EIP6963ProviderInfo {
+  uuid: string;
+  name: string;
+  icon: string;
+  rdns: string;
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,6 @@ export interface EIP1193Provider {
   request: (request: { method: string, params?: Array<unknown> }) => Promise<unknown>;
 }
 
-declare global {
-  interface WindowEventMap {
-    "eip6963:announceProvider": EIP6963AnnounceProviderEvent;
-  }
-}
 
 export class EIP6963RequestProviderEvent extends Event {
   constructor() {


### PR DESCRIPTION
Continuing from #110

This PR moves away from `window['ethereum']`, and uses the EIP-6963 standard to detect the injected wallet.