### PR TITLE
fix: always return same connector instance

### DIFF
--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,16 +1,15 @@
 import Connector from './connector';
 
 export default class Lock {
-  public connectors = {};
+  public connectors: Record<string, Connector> = {};
   public options = {};
 
   addConnector(connector: any) {
-    this.connectors[connector.key] = connector.connector;
+    this.connectors[connector.key] = new connector.connector(connector.options);
     this.options[connector.key] = connector.options;
   }
 
   getConnector(key: string): Connector {
-    const options = this.options[key];
-    return new this.connectors[key](options);
+    return this.connectors[key];
   }
 }


### PR DESCRIPTION
This PR will always return the same instance for a given connector.

Before this PR, calling `.getConnector('injected')` was creating and returning a different instance on each call, even though the connector has the same options.

This will lay the groundworks for a later PR supporting EIP-6963, which will register events in the injected connector class, thus requiring that only a single connector instance exist at the same time.