### PR TITLE
feat: add `autoLogin` function

### DIFF
--- a/connectors/injected.ts
+++ b/connectors/injected.ts
@@ -8,23 +8,27 @@ export default class Connector extends LockConnector {
       try {
         await window['ethereum'].request({ method: 'eth_requestAccounts' });
       } catch (e: any) {
-        if (e.message.includes('Already processing eth_requestAccounts')) {
-          try {
-            await provider.request({
-              method: 'wallet_requestPermissions',
-              params: [{ eth_accounts: {} }]
-            });
-          } catch (e: any) {
-            if (e.code === 4001 || e.code === -32002) return;
-          }
-        }
-
+        console.log(e);
         if (e.code === 4001 || e.code === -32002) return;
       }
     } else if (window['web3']) {
       provider = window['web3'].currentProvider;
     }
     return provider;
+  }
+
+  async autoConnect() {
+    let provider;
+
+    if (window['ethereum']) {
+      provider = window['ethereum'];
+    } else if (window['web3']) {
+      provider = window['web3'].currentProvider;
+    }
+
+    const accounts = await provider.request({ method: 'eth_accounts' });
+
+    return accounts.length > 0 ? provider : null;
   }
 
   async isLoggedIn() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/lock",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "repository": "snapshot-labs/lock",
   "license": "MIT",
   "main": "dist/lock.cjs.js",

--- a/plugins/vue3.ts
+++ b/plugins/vue3.ts
@@ -32,10 +32,23 @@ export const useLock = ({ ...options }) => {
     return provider;
   }
 
+  async function autoLogin(connector: string) {
+    const lockConnector = lockClient.getConnector(connector);
+    const localProvider = await lockConnector.autoConnect();
+
+    if (!localProvider) return;
+
+    provider.value = localProvider;
+    localStorage.setItem(`_${name}.connector`, connector);
+    isAuthenticated.value = true;
+
+    return provider;
+  }
+
   async function logout() {
     const connector = await getConnector();
     if (connector) {
-      const lockConnector = lockClient.getConnector(connector);
+      const lockConnector = lockClient.getConnector(connector as string);
       await lockConnector.logout();
       localStorage.removeItem(`_${name}.connector`);
       isAuthenticated.value = false;
@@ -43,7 +56,7 @@ export const useLock = ({ ...options }) => {
     }
   }
 
-  async function getConnector() {
+  async function getConnector(): Promise<boolean | string> {
     const connector = localStorage.getItem(`_${name}.connector`);
     if (connector) {
       const lockConnector = lockClient.getConnector(connector);
@@ -59,6 +72,7 @@ export const useLock = ({ ...options }) => {
     lockClient,
     login,
     logout,
+    autoLogin,
     getConnector
   };
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -9,6 +9,10 @@ export default class Connector {
     return;
   }
 
+  async autoConnect(): Promise<any> {
+    return this.connect();
+  }
+
   logout(): any {
     return true;
   }


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/sx-monorepo/issues/478

This PR adds a new `autoLogin` function which can be used to silently log in a previously logged in user when possible, without triggering any wallets prompt.

For now, this is implemented only on the injected wallet, all other wallet will fallback to the regular login function